### PR TITLE
Remove outdated platform error check

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -148,11 +148,6 @@ process.on("SIGINT", () => void core.logger.error("Received SIGINT signal"))
 process.on("SIGTERM", () => void core.logger.error("Received SIGTERM signal"))
 
 async function doTheThing() {
-	if (typeof core.config.platform === "undefined") {
-		await core.logger.error(
-			"Unknown game version. If the game has recently updated, the framework will need to be patched by its developers. If you're using a cracked version of the game, that's the problem."
-		)
-	}
 
 	const startedDate = DateTime.now()
 


### PR DESCRIPTION
## Summary
- clean up `src/main.ts` by removing unused platform error message